### PR TITLE
Add release instructions

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,7 +1,7 @@
 cmake_minimum_required(VERSION 3.15)
 project(
 	CDBTo3DTiles
-	VERSION 0.1.0
+	VERSION 0.0.0
 	LANGUAGES C CXX
 )
 enable_testing()

--- a/README.md
+++ b/README.md
@@ -218,6 +218,17 @@ Below is the output directory of the converted San Diego 3D Tiles:
 <br/>
 </p>
 
+## Releases
+
+We release as often as needed. CDB To 3D Tiles strictly follows [semver](https://semver.org/).
+
+- Update the project version number in [CMakeLists.txt](./CMakeLists.txt)
+- Proofread [CHANGES.md](./CHANGES.md) and make any required updates
+- Make sure all unit tests pass
+- Commit and push the above changes to `master`
+- Create a git tag for the version and push it:
+  - `git tag -a 0.1.0 -m "0.1.0 release"`
+  - `git push origin 0.1.0`
 
 ## Featured Demo
 


### PR DESCRIPTION
Added release instructions to the README and changed the CMakeLists version number to 0.0.0 to correspond to CHANGES.md. After this is merged we can do the first release, and then merge https://github.com/CesiumGS/cdb-to-3dtiles/pull/23.