### PR TITLE
Fixed glb padding issue

### DIFF
--- a/CDBTo3DTiles/src/Gltf.cpp
+++ b/CDBTo3DTiles/src/Gltf.cpp
@@ -725,10 +725,8 @@ void writePaddedGLB(tinygltf::Model *gltf, std::ofstream &fs) {
     std::string glbStr = glbStream.str();
     // Get length of GLB and JSON chunk.
     // https://github.com/KhronosGroup/glTF/tree/master/specification/2.0#binary-gltf-layout
-    uint32_t glbLength;
-    std::memcpy(&glbLength, glbStr.c_str() + 8, 4);
-    uint32_t jsonChunkLength;
-    std::memcpy(&jsonChunkLength, glbStr.c_str() + 12, 4);
+    uint32_t& glbLength = *reinterpret_cast<uint32_t*>(&glbStr[8]);
+    uint32_t jsonChunkLength = *reinterpret_cast<uint32_t*>(&glbStr[12]);
     // Add padding for EXT_feature_metadata
     size_t binChunkOffset = 20 + jsonChunkLength;
     if (binChunkOffset % 8 != 0) {
@@ -738,11 +736,9 @@ void writePaddedGLB(tinygltf::Model *gltf, std::ofstream &fs) {
 
         // Update GLB length.
         glbLength += static_cast<uint32_t>(paddingByteLength);
-        glbStr[8] = static_cast<char>(glbLength);
 
         // Update JSON chunk length.
         jsonChunkLength += static_cast<uint32_t>(paddingByteLength);
-        glbStr[12] = static_cast<char>(jsonChunkLength);
     }
     // Write stream to file.
     fs << glbStr;

--- a/CDBTo3DTiles/src/Gltf.cpp
+++ b/CDBTo3DTiles/src/Gltf.cpp
@@ -726,7 +726,7 @@ void writePaddedGLB(tinygltf::Model *gltf, std::ofstream &fs) {
     // Get length of GLB and JSON chunk.
     // https://github.com/KhronosGroup/glTF/tree/master/specification/2.0#binary-gltf-layout
     uint32_t& glbLength = *reinterpret_cast<uint32_t*>(&glbStr[8]);
-    uint32_t jsonChunkLength = *reinterpret_cast<uint32_t*>(&glbStr[12]);
+    uint32_t& jsonChunkLength = *reinterpret_cast<uint32_t*>(&glbStr[12]);
     // Add padding for EXT_feature_metadata
     size_t binChunkOffset = 20 + jsonChunkLength;
     if (binChunkOffset % 8 != 0) {

--- a/CDBTo3DTiles/src/Gltf.cpp
+++ b/CDBTo3DTiles/src/Gltf.cpp
@@ -732,13 +732,14 @@ void writePaddedGLB(tinygltf::Model *gltf, std::ofstream &fs) {
     if (binChunkOffset % 8 != 0) {
         // Add padding (using spaces) to JSON chunk data.
         size_t paddingByteLength = roundUp(binChunkOffset, 8) - binChunkOffset;
-        glbStr.insert(binChunkOffset, paddingByteLength, ' ');
 
         // Update GLB length.
         glbLength += static_cast<uint32_t>(paddingByteLength);
 
         // Update JSON chunk length.
         jsonChunkLength += static_cast<uint32_t>(paddingByteLength);
+
+        glbStr.insert(binChunkOffset, paddingByteLength, ' ');
     }
     // Write stream to file.
     fs << glbStr;


### PR DESCRIPTION
When adding padding to a glb to align to 8-byte boundaries, I don't think the glb's length and the json chunk's length were being properly updated. The new uint32_t byte lengths after padding were being static_cast to a char and put in the left-most byte of the byte length slots within the glb buffer.