### PR TITLE
Fix padding in combineGltfs

### DIFF
--- a/CDBTo3DTiles/src/Gltf.cpp
+++ b/CDBTo3DTiles/src/Gltf.cpp
@@ -574,7 +574,7 @@ void combineGltfs(tinygltf::Model *model, std::vector<tinygltf::Model> glbs) {
     for (auto &glbModel : glbs) {
 
         // Copy buffer data.
-        bufferData.resize(bufferByteLength + glbModel.buffers[0].data.size() + glbModel.buffers[0].data.size() % 8);
+        bufferData.resize(bufferByteLength + roundUp(glbModel.buffers[0].data.size(), 8));
         std::memcpy(bufferData.data() + bufferByteLength, glbModel.buffers[0].data.data(), glbModel.buffers[0].data.size());
 
         // Append bufferViews.


### PR DESCRIPTION
I noticed some byte offset issues when loading the GTModels tileset and tracked it down to incorrect padding in `combineGltfs`. I did a quick search for other areas that handle padding and it seems like only this area has the problem.

```
A 3D tile failed to load: http://localhost:8002/static/Desktop/temp/CDB_yemen/Tiles/N12/E045/GTModels/2_1/N12E045_D101_S002_T001_L5_U24_R0.glb
Error: Failed to load model: http://localhost:8002/static/Desktop/temp/CDB_yemen/Tiles/N12/E045/GTModels/2_1/N12E045_D101_S002_T001_L5_U24_R0.glb
Failed to load glTF
Failed to load index buffer
start offset of Uint32Array should be a multiple of 4
A 3D tile failed to load: http://localhost:8002/static/Desktop/temp/CDB_yemen/Tiles/N12/E045/GTModels/2_1/N12E045_D101_S002_T001_L5_U25_R0.glb
Error: Failed to load model: http://localhost:8002/static/Desktop/temp/CDB_yemen/Tiles/N12/E045/GTModels/2_1/N12E045_D101_S002_T001_L5_U25_R0.glb
Failed to load glTF
Failed to load index buffer
start offset of Uint32Array should be a multiple of 4
```